### PR TITLE
Callback invoked two times on error

### DIFF
--- a/exec.js
+++ b/exec.js
@@ -27,6 +27,7 @@ function exec(args, opts, callback) {
   var err;
   var encoding;
   var timeout;
+  var done = false;
 
   // check encoding
   if (opts.encoding !== 'buffer' && Buffer.isEncoding(opts.encoding)) {
@@ -63,6 +64,10 @@ function exec(args, opts, callback) {
   });
 
   child.on('close', function(code) {
+    if (done)
+        return;
+    done = true;
+
     if (timeout)
       clearTimeout(timeout);
 
@@ -75,6 +80,10 @@ function exec(args, opts, callback) {
   });
 
   child.on('error', function(e) {
+    if (done)
+        return;
+    done = true;
+    
     callback(e);
   });
 


### PR DESCRIPTION
Test case:

``` js
var exec = require('exec');

exec(['nooooo'], function(err, out, code) {
    console.log('CALLBACK!', err, out, code);
});
```

Result:

```
❯ node t.js
CALLBACK! { [Error: spawn ENOENT] code: 'ENOENT', errno: 'ENOENT', syscall: 'spawn' } undefined undefined
CALLBACK! execvp(): No such file or directory
  -1
```
