### PR TITLE
Fixed a bug with stdio pipes

### DIFF
--- a/exec.js
+++ b/exec.js
@@ -47,23 +47,32 @@ function exec(args, opts, callback) {
   var child = spawn(args[0], args.slice(1), opts);
 
   if (encoding) {
-    child.stdout.setEncoding(encoding);
-    child.stderr.setEncoding(encoding);
+    if (child.stdout) {
+		  child.stdout.setEncoding(encoding);
+    }
+		if (child.stderr) {
+      child.stderr.setEncoding(encoding);
+    }
   }
 
-  child.stdout.on('data', function(data) {
-    if (encoding)
-      out += data;
-    else
-      out.push(data);
-  });
+  if (child.stdout) {
+    child.stdout.on('data', function(data) {
+      if (encoding)
+        out += data;
+      else
+        out.push(data);
+    });
+  }
 
-  child.stderr.on('data', function(data) {
-    if (encoding)
-      err += data;
-    else
-      err.push(data);
-  });
+
+  if (child.strerr) {
+    child.stderr.on('data', function(data) {
+      if (encoding)
+        err += data;
+      else
+        err.push(data);
+    });
+  }
 
   child.on('close', function(code) {
     if (done)


### PR DESCRIPTION
If you forwarded the stdio streams, then they would be undefined, causing exec to throw an exception since child.std... would be undefined. To fix this, I added a check to see if the streams exist before doing anything to them.

Code to reproduce:

```
exec(
    ['ls'],
    {
        stdio: 'inherit'
    },
    function(){}
);
```
